### PR TITLE
Refactor chat handling

### DIFF
--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class ChatController extends Controller
+{
+    public function index(): View
+    {
+        return view('chat');
+    }
+
+    public function send(Request $request): JsonResponse
+    {
+        usleep(500 * 1000);
+
+        return response()->json([
+            'reply' => $request->input('message'),
+        ]);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Auth\GoogleController;
+use App\Http\Controllers\ChatController;
 use Illuminate\Support\Facades\Route;
 
 // Auth Routes
@@ -15,11 +16,8 @@ Route::middleware('guest')->group(function () {
 Route::middleware('auth')->group(function () {
     Route::redirect('/', 'chat');
 
-    Route::view('/chat', 'chat')->name('chat');
-    Route::post('/chat', function (\Illuminate\Http\Request $request) {
-        usleep(500 * 1000);
-        return response()->json(['reply' => $request->input('message')]);
-    });
+    Route::get('/chat', [ChatController::class, 'index'])->name('chat');
+    Route::post('/chat', [ChatController::class, 'send']);
 
     Route::post('/logout', [GoogleController::class, 'logout'])->name('logout');
 });


### PR DESCRIPTION
## Summary
- extract chat handling logic to a controller
- route `/chat` to the new controller

## Testing
- `php artisan test --testsuite=Feature` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6864f98249d08325861314e184420e88